### PR TITLE
Issue #209 - Start command for powershell users

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,3 +49,7 @@ On subsequent runs just start Snowstorm (in read only mode).
 ```bash
 java -Xms2g -Xmx4g -jar target/snowstorm*.jar --snowstorm.rest-api.readonly=true
 ```
+For Powershell Users
+```bash
+java -Xms2g -Xmx4g -jar "target/<SNOMED-JAR-NAME>.jar" --snowstorm.rest-api.readonly=true
+```


### PR DESCRIPTION
Quotes are added in the command and one has to write exact filename along with target directory because of the quotes.